### PR TITLE
Add release-on-merge GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Release on merge to main
+
+# When a PR is merged into main, cut the next release: a release/X.Y.Z branch,
+# a vX.Y.Z tag, and a GitHub Release. The bump size comes from a PR label
+# (major / minor / patch); with no label it defaults to a patch bump.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Compute next version
+        id: ver
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          set -euo pipefail
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          latest=${latest:-v0.0.0}
+          IFS=. read -r major minor patch <<< "${latest#v}"
+          case " $LABELS " in
+            *" major "*) major=$((major+1)); minor=0; patch=0 ;;
+            *" minor "*) minor=$((minor+1)); patch=0 ;;
+            *)           patch=$((patch+1)) ;;
+          esac
+          echo "tag=v${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+          echo "branch=release/${major}.${minor}.${patch}" >> "$GITHUB_OUTPUT"
+          echo "Previous: ${latest} -> next: v${major}.${minor}.${patch}"
+
+      - name: Cut release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ver.outputs.tag }}
+          BRANCH: ${{ steps.ver.outputs.branch }}
+        run: |
+          set -euo pipefail
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::notice::$TAG already exists; nothing to do."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git branch "$BRANCH"
+          git push origin "$BRANCH"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          gh release create "$TAG" --target "$TAG" --generate-notes --title "$TAG"


### PR DESCRIPTION
Adds a release-on-merge GitHub Action, on its own so it lands on `main` before the PRs it should release.

On every PR merged into `main`, it:
- reads the latest `v*` tag and bumps per a `major`/`minor`/`patch` label on the merged PR (no label → patch),
- creates the `release/X.Y.Z` branch, the `vX.Y.Z` tag, and a GitHub Release with auto-generated notes.

Label-driven (rather than conventional commits or always-major) because the repo's commits are free-form; one optional label per PR keeps semver correct with minimal effort. The `major`/`minor`/`patch` labels already exist in the repo.

Merge this first; the next PR merged after it will be the first to get an automatic release.

This pull request and its description were written by Isaac.
