### PR TITLE
Fix release workflow: invalid --target on gh release create

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
           git push origin "$BRANCH"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-          gh release create "$TAG" --target "$TAG" --generate-notes --title "$TAG"
+          gh release create "$TAG" --verify-tag --generate-notes --title "$TAG"


### PR DESCRIPTION
The release workflow failed on its first two runs (the #62 and #60 merges) at the `gh release create` step:

```
HTTP 422: Validation Failed
Release.target_commitish is invalid
```

`gh release create --target` expects a branch name or commit SHA, but it was passed the tag name. The branch and tag are already created in the step just above, so the release should simply reference the existing tag. Fix: drop `--target` and use `--verify-tag`.

The `v2.0.1`/`v2.0.2` tags, release branches, and (backfilled) GitHub Releases from those first runs are intact; this just makes future runs complete. Merging this PR will exercise the fix and cut `v2.0.3`.

This pull request and its description were written by Isaac.
